### PR TITLE
【Flutter研修: Tutorial2.2】賃貸アプリ模写

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,12 +3,16 @@ import 'tutorial_1/animation_page.dart';
 import 'youtube/youtube_screen.dart';
 import 'residence/residence_screen.dart';
 
-void main() => runApp(MainApp());
+void main() => runApp(
+      MainApp(),
+    );
 
 class MainApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(home: IndexPage());
+    return MaterialApp(
+      home: IndexPage(),
+    );
   }
 }
 
@@ -16,7 +20,9 @@ class IndexPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(title: Text('目次')),
+        appBar: AppBar(
+          title: const Text('目次'),
+        ),
         body: Center(
             child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -27,7 +33,8 @@ class IndexPage extends StatelessWidget {
                   Navigator.push(
                     context,
                     MaterialPageRoute(
-                        builder: (context) => const AnimationPage()),
+                      builder: (context) => const AnimationPage(),
+                    ),
                   );
                 }),
             ElevatedButton(
@@ -36,7 +43,8 @@ class IndexPage extends StatelessWidget {
                   Navigator.push(
                     context,
                     MaterialPageRoute(
-                        builder: (context) => const YoutubeScreen()),
+                      builder: (context) => const YoutubeScreen(),
+                    ),
                   );
                 }),
             ElevatedButton(
@@ -45,7 +53,8 @@ class IndexPage extends StatelessWidget {
                   Navigator.push(
                     context,
                     MaterialPageRoute(
-                        builder: (context) => const ResidenceScreen()),
+                      builder: (context) => const ResidenceScreen(),
+                    ),
                   );
                 }),
           ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'tutorial_1/animation_page.dart';
 import 'youtube/youtube_screen.dart';
+import 'residence/residence_screen.dart';
 
 void main() => runApp(MainApp());
 
@@ -36,6 +37,15 @@ class IndexPage extends StatelessWidget {
                     context,
                     MaterialPageRoute(
                         builder: (context) => const YoutubeScreen()),
+                  );
+                }),
+            ElevatedButton(
+                child: const Text("賃貸アプリ"),
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (context) => const ResidenceScreen()),
                   );
                 }),
           ],

--- a/lib/residence/residence_screen.dart
+++ b/lib/residence/residence_screen.dart
@@ -1,4 +1,4 @@
-import 'dart:ui';
+//import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -13,7 +13,10 @@ class ResidenceScreen extends StatelessWidget {
         appBar: _buildAppBar(context),
         body: SingleChildScrollView(
           child: Column(
-            children: [],
+            children: [
+              _buildRecomendSection(),
+              for (var i = 0; i < 10; i++) _buildRoomInformationSection(),
+            ],
           ),
         ),
         bottomNavigationBar: _bottomNavigationBar(context));
@@ -35,10 +38,10 @@ AppBar _buildAppBar(BuildContext context) {
           child: ElevatedButton(
             child: const Text(
               "おすすめ",
-              style: TextStyle(color: const Color.fromARGB(255, 45, 144, 174)),
+              style: TextStyle(color: Color.fromARGB(255, 45, 144, 174)),
             ),
             style: ElevatedButton.styleFrom(
-              primary: Color.fromARGB(161, 172, 175, 182),
+              primary: const Color.fromARGB(161, 172, 175, 182),
               shape: const StadiumBorder(),
             ),
             onPressed: () {},
@@ -52,7 +55,7 @@ AppBar _buildAppBar(BuildContext context) {
           child: ElevatedButton(
             child: const Text(
               "リフォーム",
-              style: TextStyle(color: const Color.fromARGB(255, 45, 144, 174)),
+              style: TextStyle(color: Color.fromARGB(255, 45, 144, 174)),
             ),
             style: ElevatedButton.styleFrom(
               primary: const Color.fromARGB(161, 172, 175, 182),
@@ -73,15 +76,220 @@ AppBar _buildAppBar(BuildContext context) {
   );
 }
 
-BottomNavigationBar _bottomNavigationBar(BuildContext context) {
-  return BottomNavigationBar(items: const [
-    BottomNavigationBarItem(
-      icon: Icon(Icons.home),
-      label: 'ホーム',
+Widget _buildRecomendSection() {
+  return Padding(
+    padding: const EdgeInsets.all(13.0),
+    child: Container(
+      decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: Colors.black26)),
+      child: Column(
+        children: [
+          Row(
+            children: const [
+              Padding(
+                padding: EdgeInsets.all(8.0),
+                child: Text(
+                  "カウルのおすすめ",
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 17,
+                  ),
+                ),
+              ),
+              Text(
+                "新着３件",
+                style: TextStyle(
+                  color: Color.fromARGB(255, 219, 73, 73),
+                  fontSize: 17,
+                ),
+              ),
+              SizedBox(
+                width: 80,
+              ),
+              Text(
+                "編集",
+                style: TextStyle(
+                  color: Color.fromARGB(255, 45, 144, 174),
+                ),
+              ),
+              Icon(
+                Icons.edit,
+                color: Color.fromARGB(255, 45, 144, 174),
+              )
+            ],
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Container(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(10),
+                  color: const Color.fromARGB(66, 119, 114, 114),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Column(
+                    children: [
+                      Row(
+                        children: const [
+                          Icon(Icons.train),
+                          Text("東京駅・品川駅・川崎駅・横浜駅・目黒駅"),
+                        ],
+                      ),
+                      Row(
+                        children: const [
+                          Icon(Icons.paid),
+                          Text("下限なし〜2,000万円"),
+                        ],
+                      ),
+                      Row(children: const [
+                        Icon(Icons.info),
+                        Text("1R~4LDK / 10㎡以上 / 徒歩20分"),
+                      ]),
+                    ],
+                  ),
+                )),
+          ),
+        ],
+      ),
     ),
-    BottomNavigationBarItem(
-      icon: Icon(Icons.favorite_outline_outlined),
-      label: 'お気に入り',
-    )
-  ]);
+  );
+}
+
+Widget _buildRoomInformationSection() {
+  return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Container(
+        decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(10),
+            border: Border.all(color: Colors.black26)),
+        child: Column(children: [
+          Row(
+            children: <Widget>[
+              Expanded(
+                  child: Image.network(
+                      "https://content.es-ws.jp/cpool/5060/000/000/020/047/14-1.jpg")),
+              Expanded(
+                  child: Image.network(
+                      "https://suumo.jp/article/oyakudachi/wp-content/uploads/2019/03/madorizu_sub04.jpg"))
+            ],
+          ),
+          Padding(
+            padding: const EdgeInsets.only(left: 15),
+            child: Row(
+              children: const [
+                Text(
+                  "Rising place 川崎",
+                  style: TextStyle(fontWeight: FontWeight.w800, fontSize: 20),
+                )
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(left: 15),
+            child: Row(
+              children: const [
+                Text(
+                  "2,000万円",
+                  style: TextStyle(
+                      fontWeight: FontWeight.w800,
+                      fontSize: 20,
+                      color: Color.fromARGB(255, 219, 73, 73)),
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(left: 15),
+            child: Column(
+              children: [
+                Row(children: const [
+                  Icon(Icons.train),
+                  Text("test~~~~~~~~~~~~~~"),
+                ]),
+                Row(children: const [
+                  Icon(Icons.dashboard),
+                  Text("testtesttesttesttesttesttesttest"),
+                ]),
+                Row(children: const [
+                  Icon(Icons.apartment),
+                  Text("testtesttesttesttesttesttesttest"),
+                ]),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(15.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                SizedBox(
+                  width: 150,
+                  child: ElevatedButton.icon(
+                    onPressed: () {},
+                    icon: const Icon(
+                      Icons.delete,
+                      color: Color.fromARGB(213, 90, 86, 86),
+                    ),
+                    label: const Text(
+                      "興味なし",
+                      style: TextStyle(color: Color.fromARGB(213, 90, 86, 86)),
+                    ),
+                    style: ElevatedButton.styleFrom(
+                        primary: Colors.white,
+                        side: const BorderSide(
+                          color: Color.fromARGB(66, 119, 114, 114),
+                        )),
+                  ),
+                ),
+                SizedBox(
+                  width: 150,
+                  child: ElevatedButton.icon(
+                    onPressed: () {},
+                    icon: const Icon(
+                      Icons.favorite_border,
+                      color: Color.fromARGB(213, 90, 86, 86),
+                    ),
+                    label: const Text(
+                      "お気に入り",
+                      style: TextStyle(color: Color.fromARGB(213, 90, 86, 86)),
+                    ),
+                    style: ElevatedButton.styleFrom(
+                        primary: Colors.white,
+                        side: const BorderSide(
+                          color: Color.fromARGB(66, 119, 114, 114),
+                        )),
+                  ),
+                ),
+              ],
+            ),
+          )
+        ]),
+      ));
+}
+
+BottomNavigationBar _bottomNavigationBar(BuildContext context) {
+  return BottomNavigationBar(
+    items: const [
+      BottomNavigationBarItem(
+        icon: Icon(Icons.home),
+        label: 'ホーム',
+      ),
+      BottomNavigationBarItem(
+        icon: Icon(Icons.favorite_outline_outlined),
+        label: 'お気に入り',
+      ),
+      BottomNavigationBarItem(
+        icon: Icon(Icons.chat),
+        label: 'メッセージ',
+      ),
+      BottomNavigationBarItem(
+        icon: Icon(Icons.perm_identity),
+        label: 'マイページ',
+      ),
+    ],
+    selectedItemColor: const Color.fromARGB(255, 45, 144, 174),
+    unselectedItemColor: const Color.fromARGB(161, 172, 175, 182),
+    type: BottomNavigationBarType.fixed,
+  );
 }

--- a/lib/residence/residence_screen.dart
+++ b/lib/residence/residence_screen.dart
@@ -11,7 +11,7 @@ class ResidenceScreen extends StatelessWidget {
         body: SingleChildScrollView(
           child: Column(
             children: [
-              _buildRecomendSection(),
+              _buildEditConditionSection(),
               for (var i = 0; i < 10; i++) _buildRoomInformationSection(),
             ],
           ),
@@ -79,8 +79,8 @@ AppBar _buildAppBar(BuildContext context) {
   );
 }
 
-// おすすめ物件セクションを構築
-Widget _buildRecomendSection() {
+// 条件設定セクションを構築
+Widget _buildEditConditionSection() {
   return Padding(
     padding: const EdgeInsets.all(13.0),
     child: Container(

--- a/lib/residence/residence_screen.dart
+++ b/lib/residence/residence_screen.dart
@@ -7,21 +7,27 @@ class ResidenceScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: _buildAppBar(context),
-        body: SingleChildScrollView(
-          child: Column(
-            children: [
-              _buildEditConditionSection(),
-              for (var i = 0; i < 10; i++) _buildRoomInformationSection(),
-            ],
-          ),
+      appBar: _buildAppBar(context),
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            _buildEditConditionSection(),
+            for (var i = 0; i < 10; i++) _buildRoomInformationSection(),
+          ],
         ),
-        floatingActionButton: FloatingActionButton(
-          onPressed: () {},
-          child: const Icon(Icons.add),
-          backgroundColor: const Color.fromARGB(255, 45, 144, 174),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {},
+        child: const Icon(Icons.add),
+        backgroundColor: const Color.fromARGB(
+          255,
+          45,
+          144,
+          174,
         ),
-        bottomNavigationBar: _bottomNavigationBar(context));
+      ),
+      bottomNavigationBar: _bottomNavigationBar(context),
+    );
   }
 }
 
@@ -32,7 +38,12 @@ AppBar _buildAppBar(BuildContext context) {
     leading: IconButton(
       icon: const Icon(Icons.arrow_back_ios),
       onPressed: () {},
-      color: const Color.fromARGB(255, 45, 144, 174),
+      color: const Color.fromARGB(
+        255,
+        45,
+        144,
+        174,
+      ),
     ),
     title: Row(
       children: [
@@ -41,10 +52,22 @@ AppBar _buildAppBar(BuildContext context) {
           child: ElevatedButton(
             child: const Text(
               "おすすめ",
-              style: TextStyle(color: Color.fromARGB(255, 45, 144, 174)),
+              style: TextStyle(
+                color: Color.fromARGB(
+                  255,
+                  45,
+                  144,
+                  174,
+                ),
+              ),
             ),
             style: ElevatedButton.styleFrom(
-              primary: const Color.fromARGB(161, 172, 175, 182),
+              primary: const Color.fromARGB(
+                161,
+                172,
+                175,
+                182,
+              ),
               shape: const StadiumBorder(),
             ),
             onPressed: () {},
@@ -58,10 +81,22 @@ AppBar _buildAppBar(BuildContext context) {
           child: ElevatedButton(
             child: const Text(
               "リフォーム",
-              style: TextStyle(color: Color.fromARGB(255, 45, 144, 174)),
+              style: TextStyle(
+                color: Color.fromARGB(
+                  255,
+                  45,
+                  144,
+                  174,
+                ),
+              ),
             ),
             style: ElevatedButton.styleFrom(
-              primary: const Color.fromARGB(161, 172, 175, 182),
+              primary: const Color.fromARGB(
+                161,
+                172,
+                175,
+                182,
+              ),
               shape: const StadiumBorder(),
             ),
             onPressed: () {},
@@ -73,7 +108,12 @@ AppBar _buildAppBar(BuildContext context) {
       IconButton(
         onPressed: () {},
         icon: const Icon(Icons.add_circle),
-        color: const Color.fromARGB(255, 45, 144, 174),
+        color: const Color.fromARGB(
+          255,
+          45,
+          144,
+          174,
+        ),
       ),
     ],
   );
@@ -85,8 +125,9 @@ Widget _buildEditConditionSection() {
     padding: const EdgeInsets.all(13.0),
     child: Container(
       decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(10),
-          border: Border.all(color: Colors.black26)),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: Colors.black26),
+      ),
       child: Column(
         children: [
           Row(
@@ -104,7 +145,12 @@ Widget _buildEditConditionSection() {
               Text(
                 "新着３件",
                 style: TextStyle(
-                  color: Color.fromARGB(255, 219, 73, 73),
+                  color: Color.fromARGB(
+                    255,
+                    219,
+                    73,
+                    73,
+                  ),
                   fontSize: 17,
                 ),
               ),
@@ -114,45 +160,61 @@ Widget _buildEditConditionSection() {
               Text(
                 "編集",
                 style: TextStyle(
-                  color: Color.fromARGB(255, 45, 144, 174),
+                  color: Color.fromARGB(
+                    255,
+                    45,
+                    144,
+                    174,
+                  ),
                 ),
               ),
               Icon(
                 Icons.edit,
-                color: Color.fromARGB(255, 45, 144, 174),
+                color: Color.fromARGB(
+                  255,
+                  45,
+                  144,
+                  174,
+                ),
               )
             ],
           ),
           Padding(
             padding: const EdgeInsets.all(8.0),
             child: Container(
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(10),
-                  color: const Color.fromARGB(66, 119, 114, 114),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(10),
+                color: const Color.fromARGB(
+                  66,
+                  119,
+                  114,
+                  114,
                 ),
-                child: Padding(
-                  padding: const EdgeInsets.all(8.0),
-                  child: Column(
-                    children: [
-                      Row(
-                        children: const [
-                          Icon(Icons.train),
-                          Text("東京駅・品川駅・川崎駅・横浜駅・目黒駅"),
-                        ],
-                      ),
-                      Row(
-                        children: const [
-                          Icon(Icons.paid),
-                          Text("下限なし〜2,000万円"),
-                        ],
-                      ),
-                      Row(children: const [
-                        Icon(Icons.info),
-                        Text("1R~4LDK / 10㎡以上 / 徒歩20分"),
-                      ]),
-                    ],
-                  ),
-                )),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Column(
+                  children: [
+                    Row(
+                      children: const [
+                        Icon(Icons.train),
+                        Text("東京駅・品川駅・川崎駅・横浜駅・目黒駅"),
+                      ],
+                    ),
+                    Row(
+                      children: const [
+                        Icon(Icons.paid),
+                        Text("下限なし〜2,000万円"),
+                      ],
+                    ),
+                    Row(children: const [
+                      Icon(Icons.info),
+                      Text("1R~4LDK / 10㎡以上 / 徒歩20分"),
+                    ]),
+                  ],
+                ),
+              ),
+            ),
           ),
         ],
       ),
@@ -163,114 +225,158 @@ Widget _buildEditConditionSection() {
 // 部屋情報一覧セクションを構築
 Widget _buildRoomInformationSection() {
   return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: Container(
-        decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(10),
-            border: Border.all(color: Colors.black26)),
-        child: Column(children: [
-          Row(
-            children: <Widget>[
-              Expanded(
-                  child: Image.network(
-                      "https://content.es-ws.jp/cpool/5060/000/000/020/047/14-1.jpg")),
-              Expanded(
-                  child: Image.network(
-                      "https://suumo.jp/article/oyakudachi/wp-content/uploads/2019/03/madorizu_sub04.jpg"))
+    padding: const EdgeInsets.all(8.0),
+    child: Container(
+      decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: Colors.black26)),
+      child: Column(children: [
+        Row(
+          children: <Widget>[
+            Expanded(
+                child: Image.network(
+                    "https://content.es-ws.jp/cpool/5060/000/000/020/047/14-1.jpg")),
+            Expanded(
+                child: Image.network(
+                    "https://suumo.jp/article/oyakudachi/wp-content/uploads/2019/03/madorizu_sub04.jpg"))
+          ],
+        ),
+        Padding(
+          padding: const EdgeInsets.only(left: 15),
+          child: Row(
+            children: const [
+              Text(
+                "Rising place 川崎",
+                style: TextStyle(
+                  fontWeight: FontWeight.w800,
+                  fontSize: 20,
+                ),
+              )
             ],
           ),
-          Padding(
-            padding: const EdgeInsets.only(left: 15),
-            child: Row(
-              children: const [
-                Text(
-                  "Rising place 川崎",
-                  style: TextStyle(fontWeight: FontWeight.w800, fontSize: 20),
-                )
-              ],
-            ),
+        ),
+        Padding(
+          padding: const EdgeInsets.only(left: 15),
+          child: Row(
+            children: const [
+              Text(
+                "2,000万円",
+                style: TextStyle(
+                    fontWeight: FontWeight.w800,
+                    fontSize: 20,
+                    color: Color.fromARGB(
+                      255,
+                      219,
+                      73,
+                      73,
+                    )),
+              ),
+            ],
           ),
-          Padding(
-            padding: const EdgeInsets.only(left: 15),
-            child: Row(
-              children: const [
-                Text(
-                  "2,000万円",
-                  style: TextStyle(
-                      fontWeight: FontWeight.w800,
-                      fontSize: 20,
-                      color: Color.fromARGB(255, 219, 73, 73)),
-                ),
-              ],
-            ),
+        ),
+        Padding(
+          padding: const EdgeInsets.only(left: 15),
+          child: Column(
+            children: [
+              Row(children: const [
+                Icon(Icons.train),
+                Text("test~~~~~~~~~~~~~~"),
+              ]),
+              Row(children: const [
+                Icon(Icons.dashboard),
+                Text("testtesttesttesttesttesttesttest"),
+              ]),
+              Row(children: const [
+                Icon(Icons.apartment),
+                Text("testtesttesttesttesttesttesttest"),
+              ]),
+            ],
           ),
-          Padding(
-            padding: const EdgeInsets.only(left: 15),
-            child: Column(
-              children: [
-                Row(children: const [
-                  Icon(Icons.train),
-                  Text("test~~~~~~~~~~~~~~"),
-                ]),
-                Row(children: const [
-                  Icon(Icons.dashboard),
-                  Text("testtesttesttesttesttesttesttest"),
-                ]),
-                Row(children: const [
-                  Icon(Icons.apartment),
-                  Text("testtesttesttesttesttesttesttest"),
-                ]),
-              ],
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.all(15.0),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: [
-                SizedBox(
-                  width: 150,
-                  child: ElevatedButton.icon(
-                    onPressed: () {},
-                    icon: const Icon(
-                      Icons.delete,
-                      color: Color.fromARGB(213, 90, 86, 86),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(15.0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              SizedBox(
+                width: 150,
+                child: ElevatedButton.icon(
+                  onPressed: () {},
+                  icon: const Icon(
+                    Icons.delete,
+                    color: Color.fromARGB(
+                      213,
+                      90,
+                      86,
+                      86,
                     ),
-                    label: const Text(
-                      "興味なし",
-                      style: TextStyle(color: Color.fromARGB(213, 90, 86, 86)),
+                  ),
+                  label: const Text(
+                    "興味なし",
+                    style: TextStyle(
+                      color: Color.fromARGB(
+                        213,
+                        90,
+                        86,
+                        86,
+                      ),
                     ),
-                    style: ElevatedButton.styleFrom(
-                        primary: Colors.white,
-                        side: const BorderSide(
-                          color: Color.fromARGB(66, 119, 114, 114),
-                        )),
+                  ),
+                  style: ElevatedButton.styleFrom(
+                    primary: Colors.white,
+                    side: const BorderSide(
+                      color: Color.fromARGB(
+                        66,
+                        119,
+                        114,
+                        114,
+                      ),
+                    ),
                   ),
                 ),
-                SizedBox(
-                  width: 150,
-                  child: ElevatedButton.icon(
-                    onPressed: () {},
-                    icon: const Icon(
-                      Icons.favorite_border,
-                      color: Color.fromARGB(213, 90, 86, 86),
+              ),
+              SizedBox(
+                width: 150,
+                child: ElevatedButton.icon(
+                  onPressed: () {},
+                  icon: const Icon(
+                    Icons.favorite_border,
+                    color: Color.fromARGB(
+                      213,
+                      90,
+                      86,
+                      86,
                     ),
-                    label: const Text(
-                      "お気に入り",
-                      style: TextStyle(color: Color.fromARGB(213, 90, 86, 86)),
+                  ),
+                  label: const Text(
+                    "お気に入り",
+                    style: TextStyle(
+                        color: Color.fromARGB(
+                      213,
+                      90,
+                      86,
+                      86,
+                    )),
+                  ),
+                  style: ElevatedButton.styleFrom(
+                    primary: Colors.white,
+                    side: const BorderSide(
+                      color: Color.fromARGB(
+                        66,
+                        119,
+                        114,
+                        114,
+                      ),
                     ),
-                    style: ElevatedButton.styleFrom(
-                        primary: Colors.white,
-                        side: const BorderSide(
-                          color: Color.fromARGB(66, 119, 114, 114),
-                        )),
                   ),
                 ),
-              ],
-            ),
-          )
-        ]),
-      ));
+              ),
+            ],
+          ),
+        )
+      ]),
+    ),
+  );
 }
 
 // ボトムナビゲーションバーを構築
@@ -291,22 +397,22 @@ BottomNavigationBar _bottomNavigationBar(BuildContext context) {
           children: [
             const Icon(Icons.chat),
             Positioned(
-                right: -5,
-                top: -4,
-                child: Container(
-                  decoration: const BoxDecoration(
-                    color: Colors.red,
-                    shape: BoxShape.circle,
+              right: -5,
+              top: -4,
+              child: Container(
+                decoration: const BoxDecoration(
+                  color: Colors.red,
+                  shape: BoxShape.circle,
+                ),
+                constraints: const BoxConstraints(minHeight: 15, minWidth: 15),
+                child: const Center(
+                  child: Text(
+                    "1",
+                    style: TextStyle(color: Colors.white),
                   ),
-                  constraints:
-                      const BoxConstraints(minHeight: 15, minWidth: 15),
-                  child: const Center(
-                    child: Text(
-                      "1",
-                      style: TextStyle(color: Colors.white),
-                    ),
-                  ),
-                ))
+                ),
+              ),
+            )
           ],
         ),
         label: 'メッセージ',
@@ -316,8 +422,18 @@ BottomNavigationBar _bottomNavigationBar(BuildContext context) {
         label: 'マイページ',
       ),
     ],
-    selectedItemColor: const Color.fromARGB(255, 45, 144, 174),
-    unselectedItemColor: const Color.fromARGB(161, 172, 175, 182),
+    selectedItemColor: const Color.fromARGB(
+      255,
+      45,
+      144,
+      174,
+    ),
+    unselectedItemColor: const Color.fromARGB(
+      161,
+      172,
+      175,
+      182,
+    ),
     type: BottomNavigationBarType.fixed,
   );
 }

--- a/lib/residence/residence_screen.dart
+++ b/lib/residence/residence_screen.dart
@@ -230,38 +230,39 @@ Widget _buildRoomInformationSection() {
       decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(10),
           border: Border.all(color: Colors.black26)),
-      child: Column(children: [
-        Row(
-          children: <Widget>[
-            Expanded(
-                child: Image.network(
-                    "https://content.es-ws.jp/cpool/5060/000/000/020/047/14-1.jpg")),
-            Expanded(
-                child: Image.network(
-                    "https://suumo.jp/article/oyakudachi/wp-content/uploads/2019/03/madorizu_sub04.jpg"))
-          ],
-        ),
-        Padding(
-          padding: const EdgeInsets.only(left: 15),
-          child: Row(
-            children: const [
-              Text(
-                "Rising place 川崎",
-                style: TextStyle(
-                  fontWeight: FontWeight.w800,
-                  fontSize: 20,
-                ),
-              )
+      child: Column(
+        children: [
+          Row(
+            children: <Widget>[
+              Expanded(
+                  child: Image.network(
+                      "https://content.es-ws.jp/cpool/5060/000/000/020/047/14-1.jpg")),
+              Expanded(
+                  child: Image.network(
+                      "https://suumo.jp/article/oyakudachi/wp-content/uploads/2019/03/madorizu_sub04.jpg"))
             ],
           ),
-        ),
-        Padding(
-          padding: const EdgeInsets.only(left: 15),
-          child: Row(
-            children: const [
-              Text(
-                "2,000万円",
-                style: TextStyle(
+          Padding(
+            padding: const EdgeInsets.only(left: 15),
+            child: Row(
+              children: const [
+                Text(
+                  "Rising place 川崎",
+                  style: TextStyle(
+                    fontWeight: FontWeight.w800,
+                    fontSize: 20,
+                  ),
+                )
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(left: 15),
+            child: Row(
+              children: const [
+                Text(
+                  "2,000万円",
+                  style: TextStyle(
                     fontWeight: FontWeight.w800,
                     fontSize: 20,
                     color: Color.fromARGB(
@@ -269,51 +270,48 @@ Widget _buildRoomInformationSection() {
                       219,
                       73,
                       73,
-                    )),
-              ),
-            ],
-          ),
-        ),
-        Padding(
-          padding: const EdgeInsets.only(left: 15),
-          child: Column(
-            children: [
-              Row(children: const [
-                Icon(Icons.train),
-                Text("test~~~~~~~~~~~~~~"),
-              ]),
-              Row(children: const [
-                Icon(Icons.dashboard),
-                Text("testtesttesttesttesttesttesttest"),
-              ]),
-              Row(children: const [
-                Icon(Icons.apartment),
-                Text("testtesttesttesttesttesttesttest"),
-              ]),
-            ],
-          ),
-        ),
-        Padding(
-          padding: const EdgeInsets.all(15.0),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            children: [
-              SizedBox(
-                width: 150,
-                child: ElevatedButton.icon(
-                  onPressed: () {},
-                  icon: const Icon(
-                    Icons.delete,
-                    color: Color.fromARGB(
-                      213,
-                      90,
-                      86,
-                      86,
                     ),
                   ),
-                  label: const Text(
-                    "興味なし",
-                    style: TextStyle(
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(left: 15),
+            child: Column(
+              children: [
+                Row(
+                  children: const [
+                    Icon(Icons.train),
+                    Text("test~~~~~~~~~~~~~~"),
+                  ],
+                ),
+                Row(
+                  children: const [
+                    Icon(Icons.dashboard),
+                    Text("testtesttesttesttesttesttesttest"),
+                  ],
+                ),
+                Row(
+                  children: const [
+                    Icon(Icons.apartment),
+                    Text("testtesttesttesttesttesttesttest"),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(15.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                SizedBox(
+                  width: 150,
+                  child: ElevatedButton.icon(
+                    onPressed: () {},
+                    icon: const Icon(
+                      Icons.delete,
                       color: Color.fromARGB(
                         213,
                         90,
@@ -321,60 +319,72 @@ Widget _buildRoomInformationSection() {
                         86,
                       ),
                     ),
-                  ),
-                  style: ElevatedButton.styleFrom(
-                    primary: Colors.white,
-                    side: const BorderSide(
-                      color: Color.fromARGB(
-                        66,
-                        119,
-                        114,
-                        114,
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-              SizedBox(
-                width: 150,
-                child: ElevatedButton.icon(
-                  onPressed: () {},
-                  icon: const Icon(
-                    Icons.favorite_border,
-                    color: Color.fromARGB(
-                      213,
-                      90,
-                      86,
-                      86,
-                    ),
-                  ),
-                  label: const Text(
-                    "お気に入り",
-                    style: TextStyle(
+                    label: const Text(
+                      "興味なし",
+                      style: TextStyle(
                         color: Color.fromARGB(
-                      213,
-                      90,
-                      86,
-                      86,
-                    )),
-                  ),
-                  style: ElevatedButton.styleFrom(
-                    primary: Colors.white,
-                    side: const BorderSide(
-                      color: Color.fromARGB(
-                        66,
-                        119,
-                        114,
-                        114,
+                          213,
+                          90,
+                          86,
+                          86,
+                        ),
+                      ),
+                    ),
+                    style: ElevatedButton.styleFrom(
+                      primary: Colors.white,
+                      side: const BorderSide(
+                        color: Color.fromARGB(
+                          66,
+                          119,
+                          114,
+                          114,
+                        ),
                       ),
                     ),
                   ),
                 ),
-              ),
-            ],
-          ),
-        )
-      ]),
+                SizedBox(
+                  width: 150,
+                  child: ElevatedButton.icon(
+                    onPressed: () {},
+                    icon: const Icon(
+                      Icons.favorite_border,
+                      color: Color.fromARGB(
+                        213,
+                        90,
+                        86,
+                        86,
+                      ),
+                    ),
+                    label: const Text(
+                      "お気に入り",
+                      style: TextStyle(
+                        color: Color.fromARGB(
+                          213,
+                          90,
+                          86,
+                          86,
+                        ),
+                      ),
+                    ),
+                    style: ElevatedButton.styleFrom(
+                      primary: Colors.white,
+                      side: const BorderSide(
+                        color: Color.fromARGB(
+                          66,
+                          119,
+                          114,
+                          114,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          )
+        ],
+      ),
     ),
   );
 }

--- a/lib/residence/residence_screen.dart
+++ b/lib/residence/residence_screen.dart
@@ -1,0 +1,36 @@
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class ResidenceScreen extends StatelessWidget {
+  const ResidenceScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: _buildAppBar(context),
+      body: SingleChildScrollView(
+        child: Column(
+          children: [],
+        ),
+      ),
+      //bottomNavigationBar: _bottomNavigationBar(context)
+    );
+  }
+}
+
+AppBar _buildAppBar(BuildContext context) {
+  return AppBar(
+    backgroundColor: Colors.white,
+    leading: SizedBox(
+      width: 300,
+      height: 10,
+      child: ElevatedButton(
+        onPressed: () {},
+        child: const Text("おすすめ"),
+        style: const ButtonStyle(),
+      ),
+    ),
+  );
+}

--- a/lib/residence/residence_screen.dart
+++ b/lib/residence/residence_screen.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:badges/badges.dart';
 
 class ResidenceScreen extends StatelessWidget {
   const ResidenceScreen({Key? key}) : super(key: key);
@@ -9,28 +10,78 @@ class ResidenceScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: _buildAppBar(context),
-      body: SingleChildScrollView(
-        child: Column(
-          children: [],
+        appBar: _buildAppBar(context),
+        body: SingleChildScrollView(
+          child: Column(
+            children: [],
+          ),
         ),
-      ),
-      //bottomNavigationBar: _bottomNavigationBar(context)
-    );
+        bottomNavigationBar: _bottomNavigationBar(context));
   }
 }
 
 AppBar _buildAppBar(BuildContext context) {
   return AppBar(
     backgroundColor: Colors.white,
-    leading: SizedBox(
-      width: 300,
-      height: 10,
-      child: ElevatedButton(
-        onPressed: () {},
-        child: const Text("おすすめ"),
-        style: const ButtonStyle(),
-      ),
+    leading: IconButton(
+      icon: const Icon(Icons.arrow_back_ios),
+      onPressed: () {},
+      color: const Color.fromARGB(255, 45, 144, 174),
     ),
+    title: Row(
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(15.0),
+          child: ElevatedButton(
+            child: const Text(
+              "おすすめ",
+              style: TextStyle(color: const Color.fromARGB(255, 45, 144, 174)),
+            ),
+            style: ElevatedButton.styleFrom(
+              primary: Color.fromARGB(161, 172, 175, 182),
+              shape: const StadiumBorder(),
+            ),
+            onPressed: () {},
+          ),
+        ),
+        Badge(
+          badgeContent: const Text(
+            '1',
+            style: TextStyle(fontSize: 20, color: Colors.white),
+          ),
+          child: ElevatedButton(
+            child: const Text(
+              "リフォーム",
+              style: TextStyle(color: const Color.fromARGB(255, 45, 144, 174)),
+            ),
+            style: ElevatedButton.styleFrom(
+              primary: const Color.fromARGB(161, 172, 175, 182),
+              shape: const StadiumBorder(),
+            ),
+            onPressed: () {},
+          ),
+        ),
+      ],
+    ),
+    actions: <Widget>[
+      IconButton(
+        onPressed: () {},
+        icon: const Icon(Icons.add_circle),
+        color: const Color.fromARGB(255, 45, 144, 174),
+      ),
+    ],
   );
+}
+
+BottomNavigationBar _bottomNavigationBar(BuildContext context) {
+  return BottomNavigationBar(items: const [
+    BottomNavigationBarItem(
+      icon: Icon(Icons.home),
+      label: 'ホーム',
+    ),
+    BottomNavigationBarItem(
+      icon: Icon(Icons.favorite_outline_outlined),
+      label: 'お気に入り',
+    )
+  ]);
 }

--- a/lib/residence/residence_screen.dart
+++ b/lib/residence/residence_screen.dart
@@ -1,4 +1,4 @@
-//import 'dart:ui';
+import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -18,6 +18,11 @@ class ResidenceScreen extends StatelessWidget {
               for (var i = 0; i < 10; i++) _buildRoomInformationSection(),
             ],
           ),
+        ),
+        floatingActionButton: FloatingActionButton(
+          onPressed: () {},
+          child: const Icon(Icons.add),
+          backgroundColor: const Color.fromARGB(255, 45, 144, 174),
         ),
         bottomNavigationBar: _bottomNavigationBar(context));
   }
@@ -270,20 +275,42 @@ Widget _buildRoomInformationSection() {
 
 BottomNavigationBar _bottomNavigationBar(BuildContext context) {
   return BottomNavigationBar(
-    items: const [
-      BottomNavigationBarItem(
+    items: [
+      const BottomNavigationBarItem(
         icon: Icon(Icons.home),
         label: 'ホーム',
       ),
-      BottomNavigationBarItem(
+      const BottomNavigationBarItem(
         icon: Icon(Icons.favorite_outline_outlined),
         label: 'お気に入り',
       ),
       BottomNavigationBarItem(
-        icon: Icon(Icons.chat),
+        icon: Stack(
+          clipBehavior: Clip.none,
+          children: [
+            const Icon(Icons.chat),
+            Positioned(
+                right: -5,
+                top: -4,
+                child: Container(
+                  decoration: const BoxDecoration(
+                    color: Colors.red,
+                    shape: BoxShape.circle,
+                  ),
+                  constraints:
+                      const BoxConstraints(minHeight: 15, minWidth: 15),
+                  child: const Center(
+                    child: Text(
+                      "1",
+                      style: TextStyle(color: Colors.white),
+                    ),
+                  ),
+                ))
+          ],
+        ),
         label: 'メッセージ',
       ),
-      BottomNavigationBarItem(
+      const BottomNavigationBarItem(
         icon: Icon(Icons.perm_identity),
         label: 'マイページ',
       ),

--- a/lib/residence/residence_screen.dart
+++ b/lib/residence/residence_screen.dart
@@ -6,13 +6,15 @@ class ResidenceScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    const roomInformationNum = 10;
     return Scaffold(
       appBar: _buildAppBar(context),
       body: SingleChildScrollView(
         child: Column(
           children: [
             _buildEditConditionSection(),
-            for (var i = 0; i < 10; i++) _buildRoomInformationSection(),
+            for (var i = 0; i < roomInformationNum; i++)
+              _buildRoomInformationSection(),
           ],
         ),
       ),
@@ -154,9 +156,7 @@ Widget _buildEditConditionSection() {
                   fontSize: 17,
                 ),
               ),
-              SizedBox(
-                width: 80,
-              ),
+              Spacer(),
               Text(
                 "編集",
                 style: TextStyle(
@@ -207,10 +207,12 @@ Widget _buildEditConditionSection() {
                         Text("下限なし〜2,000万円"),
                       ],
                     ),
-                    Row(children: const [
-                      Icon(Icons.info),
-                      Text("1R~4LDK / 10㎡以上 / 徒歩20分"),
-                    ]),
+                    Row(
+                      children: const [
+                        Icon(Icons.info),
+                        Text("1R~4LDK / 10㎡以上 / 徒歩20分"),
+                      ],
+                    ),
                   ],
                 ),
               ),
@@ -228,52 +230,48 @@ Widget _buildRoomInformationSection() {
     padding: const EdgeInsets.all(8.0),
     child: Container(
       decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(10),
-          border: Border.all(color: Colors.black26)),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: Colors.black26),
+      ),
       child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Row(
             children: <Widget>[
               Expanded(
-                  child: Image.network(
-                      "https://content.es-ws.jp/cpool/5060/000/000/020/047/14-1.jpg")),
+                child: Image.network(
+                    "https://content.es-ws.jp/cpool/5060/000/000/020/047/14-1.jpg"),
+              ),
               Expanded(
-                  child: Image.network(
-                      "https://suumo.jp/article/oyakudachi/wp-content/uploads/2019/03/madorizu_sub04.jpg"))
+                child: Image.network(
+                    "https://suumo.jp/article/oyakudachi/wp-content/uploads/2019/03/madorizu_sub04.jpg"),
+              )
             ],
           ),
-          Padding(
-            padding: const EdgeInsets.only(left: 15),
-            child: Row(
-              children: const [
-                Text(
-                  "Rising place 川崎",
-                  style: TextStyle(
-                    fontWeight: FontWeight.w800,
-                    fontSize: 20,
-                  ),
-                )
-              ],
+          const Padding(
+            padding: EdgeInsets.only(left: 15),
+            child: Text(
+              "Rising place 川崎",
+              style: TextStyle(
+                fontWeight: FontWeight.w800,
+                fontSize: 20,
+              ),
             ),
           ),
-          Padding(
-            padding: const EdgeInsets.only(left: 15),
-            child: Row(
-              children: const [
-                Text(
-                  "2,000万円",
-                  style: TextStyle(
-                    fontWeight: FontWeight.w800,
-                    fontSize: 20,
-                    color: Color.fromARGB(
-                      255,
-                      219,
-                      73,
-                      73,
-                    ),
-                  ),
+          const Padding(
+            padding: EdgeInsets.only(left: 15),
+            child: Text(
+              "2,000万円",
+              style: TextStyle(
+                fontWeight: FontWeight.w800,
+                fontSize: 20,
+                color: Color.fromARGB(
+                  255,
+                  219,
+                  73,
+                  73,
                 ),
-              ],
+              ),
             ),
           ),
           Padding(

--- a/lib/residence/residence_screen.dart
+++ b/lib/residence/residence_screen.dart
@@ -26,7 +26,7 @@ class ResidenceScreen extends StatelessWidget {
           174,
         ),
       ),
-      bottomNavigationBar: _bottomNavigationBar(context),
+      bottomNavigationBar: _buildBottomNavigationBar(context),
     );
   }
 }
@@ -390,7 +390,7 @@ Widget _buildRoomInformationSection() {
 }
 
 // ボトムナビゲーションバーを構築
-BottomNavigationBar _bottomNavigationBar(BuildContext context) {
+BottomNavigationBar _buildBottomNavigationBar(BuildContext context) {
   return BottomNavigationBar(
     items: [
       const BottomNavigationBarItem(

--- a/lib/residence/residence_screen.dart
+++ b/lib/residence/residence_screen.dart
@@ -1,6 +1,3 @@
-import 'dart:ui';
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:badges/badges.dart';
 
@@ -28,6 +25,7 @@ class ResidenceScreen extends StatelessWidget {
   }
 }
 
+// appBarを構築
 AppBar _buildAppBar(BuildContext context) {
   return AppBar(
     backgroundColor: Colors.white,
@@ -81,6 +79,7 @@ AppBar _buildAppBar(BuildContext context) {
   );
 }
 
+// おすすめ物件セクションを構築
 Widget _buildRecomendSection() {
   return Padding(
     padding: const EdgeInsets.all(13.0),
@@ -161,6 +160,7 @@ Widget _buildRecomendSection() {
   );
 }
 
+// 部屋情報一覧セクションを構築
 Widget _buildRoomInformationSection() {
   return Padding(
       padding: const EdgeInsets.all(8.0),
@@ -273,6 +273,7 @@ Widget _buildRoomInformationSection() {
       ));
 }
 
+// ボトムナビゲーションバーを構築
 BottomNavigationBar _bottomNavigationBar(BuildContext context) {
   return BottomNavigationBar(
     items: [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  badges: ^2.0.2
 
   cupertino_icons: ^1.0.2
 


### PR DESCRIPTION
### 概要
・Flutter研修　[Tutorial2.2 - 次はFlutter製アプリの画面模写をしてみよう。](https://www.notion.so/Tutorial2-2-Flutter-9e2ecdc34a0d4047ba60064582bba215)に沿って、賃貸アプリの画面を模したものを作成。

### 仕様
・bodyに希望条件編集セクションと物件一覧を表示
・bodyはスクロール可能
・appBarとBottomNavigatinBarの一部ボタンにバッジを表示

<img src='https://user-images.githubusercontent.com/98789438/160979669-7d864288-9c73-4a32-9ee4-65337b52087a.png' width="200">

